### PR TITLE
CA-261065: use different datapaths for different connections

### DIFF
--- a/src/jbuild
+++ b/src/jbuild
@@ -11,6 +11,7 @@
     mirage-block-unix
     nbd.lwt
     uri
+    uuidm
     xcp.storage
     xen-api-client.lwt))
  )

--- a/src/main.ml
+++ b/src/main.ml
@@ -70,8 +70,10 @@ let with_block filename f =
 
 let with_attached_vdi sr vdi read_write f =
   let pid = Unix.getpid () in
-  let dbg = Printf.sprintf "xapi-nbd:with_attached_vdi/%d" pid in
-  SM.DP.create ~dbg ~id:(Printf.sprintf "xapi-nbd/%s/%d" vdi pid)
+  let connection_uuid = Uuidm.v `V4 |> Uuidm.to_string in
+  let datapath_id = Printf.sprintf "xapi-nbd/%s/%s/%d" vdi connection_uuid pid in
+  let dbg = Printf.sprintf "xapi-nbd:with_attached_vdi/%s" datapath_id in
+  SM.DP.create ~dbg ~id:datapath_id
   >>= fun dp ->
   SM.VDI.attach ~dbg ~dp ~sr ~vdi ~read_write
   >>= fun attach_info ->

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -12,6 +12,7 @@ depends: [
   "mirage-block-unix"
   "nbd" {>= "2.0.1"}
   "uri"
+  "uuidm"
   "xapi-idl"
   "xen-api-client"
 ]


### PR DESCRIPTION
This commit fixes a bug where multiple clients connecting to /
disconnecting from the samve VDI in parallel interfere with each other.

We have seen clients hanging during connection, and also error messages
like
"Caught Storage_interface.Internal_error("Vdi_automaton.Bad_transition(0, 2)")"
on the server side.

The problem is that we use the pid here to construct the datapath id,
but we have Lwt threads here, so all the threads are running in the same
process and will have the same pid, and therefore all the clients
connecting to the same VDI will have the same datapath id. However,
different connections to the same VDI should be represented by different
datapaths and therefore different id strings - in xapi, the datapath
*is* actually this id string.

This commit fixes the issue by making sure that the different Lwt
threads handling the different clients use different datapaths. There
are many ways to do this, here I used the Uuidm library to generate a
random UUID for each connection.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>