### PR TITLE
Fix Travis build by pinning to latest 2.x nbd version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ env:
     - OCAML_VERSION=4.04
     - PACKAGE=xapi-nbd
     - PINS="nbd:git://github.com/xapi-project/nbd.git#bugfix-v2.x"
+    - TESTS=false
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam
     - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,7 @@ env:
   global:
     - OCAML_VERSION=4.04
     - PACKAGE=xapi-nbd
+    - PINS="nbd:git://github.com/xapi-project/nbd.git#bugfix-v2.x"
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam
     - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam


### PR DESCRIPTION
Which contains the TLS changes required by xapi-nbd.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>