### PR TITLE
CP-24290: Remove sm calls & clean up VBDs on termination

### DIFF
--- a/src/cleanup.ml
+++ b/src/cleanup.ml
@@ -1,0 +1,178 @@
+open Lwt.Infix
+
+module Xen_api = Xen_api_lwt_unix
+
+module StringSet = Set.Make(String)
+
+let ignore_exn_log_error msg t = Lwt.catch t (fun e -> Lwt_log.error (msg ^ ": " ^ (Printexc.to_string e)))
+
+let local_login () =
+  let rpc = Xen_api.make Consts.xapi_unix_domain_socket_uri in
+  Xen_api.Session.login_with_password ~rpc ~uname:"" ~pwd:"" ~version:"1.0" ~originator:"xapi-nbd" >|= fun session_id ->
+  (rpc, session_id)
+
+(* Each with_tracking function guarantees to clean up the resources as
+   long as the function passed to it also guarantees the same. *)
+
+module VBD = struct
+  let cleanup_vbd rpc session_id vbd =
+    Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd >>= fun () ->
+    Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd
+
+  module Runtime = struct
+    let vbds_to_clean_up = ref StringSet.empty
+    let vbds_to_clean_up_mutex = Lwt_mutex.create ()
+
+    let with_tracking rpc session_id vbd f =
+      Lwt_mutex.with_lock vbds_to_clean_up_mutex (fun () -> Lwt.wrap (fun () ->
+          vbds_to_clean_up := StringSet.add vbd !vbds_to_clean_up))
+      >>= fun () ->
+      f ()
+      >>= fun () ->
+      Lwt_mutex.with_lock vbds_to_clean_up_mutex (fun () ->
+          vbds_to_clean_up := StringSet.remove vbd !vbds_to_clean_up; Lwt.return_unit)
+
+    (* Currently when the program is interrupted with a SIGNAL, we don't
+       remove the VBDs that we clean up from the persistent VBD list. However,
+       this does not cause a problem, because we ignore exceptions that happen
+       during the cleanups. *)
+    let cleanup rpc session_id =
+      Lwt_log.notice_f "Checking if there are any VBDs to clean up that leaked during runtime" >>= fun () ->
+      StringSet.elements !vbds_to_clean_up
+      |> Lwt_list.iter_s (fun vbd ->
+          ignore_exn_log_error (Printf.sprintf "Caught exception while cleaning up VBD with ref %s" vbd) (fun () ->
+              Lwt_log.warning_f "Cleaning up VBD with ref %s" vbd >>= fun () ->
+              cleanup_vbd rpc session_id vbd)
+        )
+  end
+
+  module Persistent = struct
+
+    let with_tracking rpc session_id vbd f =
+      (* Destroy the VBD and exit with the original exception if we fail in the beginning. *)
+      let (>>*=) a b =
+        Lwt.try_bind
+          (fun () -> a)
+          b
+          (fun e ->
+             Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd >>= fun () ->
+             Lwt.fail e)
+      in
+      Xen_api.VBD.get_uuid ~rpc ~session_id ~self:vbd >>*= fun vbd_uuid ->
+      Vbd_store.add vbd_uuid >>*= fun () ->
+      Lwt.finalize
+        f
+        (fun () -> Vbd_store.remove vbd_uuid)
+
+    let cleanup rpc session_id =
+      Lwt_log.notice_f "Checking if there are any VBDs to clean up that leaked during the previous run" >>= fun () ->
+      Vbd_store.get_all () >>= fun vbd_uuids ->
+      Lwt_list.iter_s
+        (fun uuid ->
+           ignore_exn_log_error (Printf.sprintf "Caught exception while cleaning up VBD with UUID %s" uuid) (fun () ->
+               Lwt_log.warning_f "Cleaning up VBD with UUID %s" uuid >>= fun () ->
+               Lwt.catch
+                 (fun () ->
+                    Xen_api.VBD.get_by_uuid ~rpc ~session_id ~uuid >>= fun vbd ->
+                    cleanup_vbd rpc session_id vbd)
+                 (function
+                   | Api_errors.Server_error (e, _) when e = Api_errors.uuid_invalid ->
+                     (* This VBD has already been cleaned up, maybe by the signal handler *)
+                     Lwt.return_unit
+                   | e -> Lwt.fail e)
+               >>= fun () ->
+               Vbd_store.remove uuid
+             )
+        )
+        vbd_uuids
+  end
+
+  let with_vbd ~vDI ~vM ~mode ~rpc ~session_id f =
+    Xen_api.VBD.create ~rpc ~session_id ~vM ~vDI ~userdevice:"autodetect" ~bootable:false ~mode ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]
+    >>= fun vbd ->
+    Persistent.with_tracking rpc session_id vbd (fun () ->
+        Runtime.with_tracking rpc session_id vbd (fun () ->
+            Lwt.finalize
+              (fun () ->
+                 Lwt_log.notice_f "Plugging VBD %s" vbd >>= fun () ->
+                 Xen_api.VBD.plug ~rpc ~session_id ~self:vbd >>= fun () ->
+                 Lwt.finalize
+                   (fun () -> f vbd)
+                   (fun () ->
+                      Lwt_log.notice_f "Unplugging VBD %s" vbd >>= fun () ->
+                      Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd)
+              )
+              (fun () ->
+                 Lwt_log.notice_f "Destroying VBD %s" vbd >>= fun () ->
+                 Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd
+              )
+          )
+      )
+end
+
+module Block = struct
+  module Runtime = struct
+    let blocks_to_close = Hashtbl.create 1
+    let blocks_to_close_mutex = Lwt_mutex.create ()
+
+    let with_tracking b f =
+      let block_uuid = Uuidm.v `V4 |> Uuidm.to_string in
+      Lwt_mutex.with_lock blocks_to_close_mutex (fun () ->
+          Hashtbl.add blocks_to_close block_uuid b; Lwt.return_unit)
+      >>= fun () ->
+      Lwt.finalize
+        f
+        (fun () ->
+           Lwt_mutex.with_lock blocks_to_close_mutex (fun () ->
+               Hashtbl.remove blocks_to_close block_uuid; Lwt.return_unit)
+        )
+
+    let cleanup () =
+      let cleanup b = ignore_exn_log_error "Caught exception while closing open block device" (fun () ->
+          Lwt_log.warning_f "Disconnecting from block device" >>= fun () ->
+          Block.disconnect b)
+      in
+      let blocks_to_close = Hashtbl.fold (fun _ b l -> b::l) blocks_to_close [] in
+      Lwt_list.iter_s cleanup blocks_to_close
+  end
+
+  let with_block filename f =
+    Block.connect filename
+    >>= function
+    | `Error e -> Lwt.fail_with (Printf.sprintf "Unable to read %s: %s" filename (Nbd.Block_error_printer.to_string e))
+    | `Ok b ->
+      Runtime.with_tracking b (fun () ->
+          Lwt.finalize
+            (fun () -> f b)
+            (fun () -> Block.disconnect b)
+        )
+end
+
+module Runtime = struct
+  let cleanup_resources signal =
+    let cleanup () =
+      Lwt_log.warning_f "Caught signal %d, cleaning up" signal >>= fun () ->
+      ignore_exn_log_error "Caught exception while closing open block devices" (fun () ->
+          Block.Runtime.cleanup ())
+      >>= fun () ->
+      ignore_exn_log_error "Caught exception while cleaning up VBDs" (fun () ->
+          local_login () >>= fun (rpc, session_id) ->
+          VBD.Runtime.cleanup rpc session_id
+        )
+    in
+
+    Lwt_main.run (cleanup ());
+    failwith (Printf.sprintf "Caught signal %d" signal)
+
+  let register_signal_handler () =
+    let signals = [ Sys.sigint; Sys.sigterm ] in
+    List.iter
+      (fun s -> Lwt_unix.on_signal s cleanup_resources |> ignore)
+      signals
+end
+
+module Persistent = struct
+  let cleanup () =
+    local_login () >>= fun (rpc, session_id) ->
+    VBD.Persistent.cleanup rpc session_id
+end

--- a/src/cleanup.mli
+++ b/src/cleanup.mli
@@ -11,16 +11,52 @@ module VBD : sig
     mode:[ `RO | `RW ] ->
     rpc:(Rpc.call -> Rpc.response Lwt.t) ->
     session_id:string -> (string -> unit Lwt.t) -> unit Lwt.t
+  (** This function takes care of cleaning up a VBD, and keeps a record of
+      it in case something goes wrong before the cleanups can finish (for
+      example the program is terminated with SIGTREM or it crashes), so
+      that we have a chance of cleaning it up in the signal handler
+      registered by {!Runtime.register_signal_handler}, or in the
+      {!Persistent.cleanup} function.  This function will fail with an
+      exception if the cleanups, the function passed to it, or
+      manipulating the record of VDIs to be cleaned up fails.
+  *)
 end
 
 module Block : sig
   val with_block : string -> (Block.t -> 'a Lwt.t) -> 'a Lwt.t
+  (** Takes care of closing the block device, and keeps a record of it in
+      case something goes wrong before the cleanups can finish (for
+      example the program is terminated with SIGTREM or it crashes), so
+      that we have a chance of cleaning it up in the signal handler
+      registered by {!Runtime.register_signal_handler}.
+  *)
 end
 
 module Runtime : sig
   val register_signal_handler : unit -> unit
+  (** Register a signal handler for SIGTERM and SIGINT, to clean up the
+      leftoveer VBDs that we've created but haven't yet cleaned up during
+      the runtime of the program.
+      If an exception happens while cleaning up a VBD, it is just logged, but
+      not propagated to the caller, and will not interrupt the cleanup of the
+      rest of the VBDs.
+      When the cleanup is finished, the handler raises an exception to
+      terminate the program.
+  *)
 end
 
 module Persistent : sig
   val cleanup : unit -> unit Lwt.t
+  (** Cleans up the VBDs that are recorded in the
+      {!Consts.vbd_list_file_name} in the {!Consts.xapi_nbd_persistent_dir}
+      directory. This function should be called at program startup, to
+      ensure that the VBDs that leaked during the last run of the program
+      that abnormally terminated do get cleaned up.
+      If an exception happens while cleaning up a VBD, it is just logged, but
+      not propagated to the caller, and will not interrupt the cleanup of the
+      rest of the VBDs. However, unexpected errors that occur while
+      reading the persistent list of VBDs to clean up, other than the file
+      not existing, will cause this function to fail and will be
+      propagated to the caller.
+  *)
 end

--- a/src/cleanup.mli
+++ b/src/cleanup.mli
@@ -1,0 +1,26 @@
+(** This module provides two independent mechanisms for cleaning up leaked
+    VBDs. They both work on their own, but they can also be combined for extra
+    safety. *)
+
+val ignore_exn_log_error : string -> (unit -> unit Lwt.t) -> unit Lwt.t
+
+module VBD : sig
+  val with_vbd :
+    vDI:string ->
+    vM:string ->
+    mode:[ `RO | `RW ] ->
+    rpc:(Rpc.call -> Rpc.response Lwt.t) ->
+    session_id:string -> (string -> unit Lwt.t) -> unit Lwt.t
+end
+
+module Block : sig
+  val with_block : string -> (Block.t -> 'a Lwt.t) -> 'a Lwt.t
+end
+
+module Runtime : sig
+  val register_signal_handler : unit -> unit
+end
+
+module Persistent : sig
+  val cleanup : unit -> unit Lwt.t
+end

--- a/src/consts.ml
+++ b/src/consts.ml
@@ -2,6 +2,9 @@
 (** Xapi's local Unix domain socket *)
 let xapi_unix_domain_socket_uri = "file:///var/xapi/xapi"
 
+(** Location of the xensource-inventory file on XenServer *)
+let xensource_inventory_filename = "/etc/xensource-inventory"
+
 (** The IANA-reserved port for NBD *)
 let standard_nbd_port = 10809
 

--- a/src/consts.ml
+++ b/src/consts.ml
@@ -9,3 +9,7 @@ let xensource_inventory_filename = "/etc/xensource-inventory"
 let standard_nbd_port = 10809
 
 let project_url = "http://github.com/xapi-project/xapi-nbd"
+
+let xapi_nbd_persistent_dir = "/var/lib/xapi-nbd"
+
+let vbd_list_file = xapi_nbd_persistent_dir ^ "/VBDs_to_clean_up"

--- a/src/consts.ml
+++ b/src/consts.ml
@@ -12,4 +12,4 @@ let project_url = "http://github.com/xapi-project/xapi-nbd"
 
 let xapi_nbd_persistent_dir = "/var/lib/xapi-nbd"
 
-let vbd_list_file = xapi_nbd_persistent_dir ^ "/VBDs_to_clean_up"
+let vbd_list_file_name = "VBDs_to_clean_up"

--- a/src/jbuild
+++ b/src/jbuild
@@ -7,12 +7,10 @@
    (cmdliner
     lwt
     lwt.unix
-    message_switch.lwt
     mirage-block-unix
     nbd.lwt
     uri
-    uuidm
-    xcp.storage
+    xcp-inventory
     xen-api-client.lwt))
  )
 )

--- a/src/jbuild
+++ b/src/jbuild
@@ -10,6 +10,7 @@
     mirage-block-unix
     nbd.lwt
     uri
+    uuidm
     xcp-inventory
     xen-api-client.lwt))
  )

--- a/src/main.ml
+++ b/src/main.ml
@@ -16,46 +16,12 @@ open Lwt.Infix
 (* Xapi external interfaces: *)
 module Xen_api = Xen_api_lwt_unix
 
-let ignore_exn_log_error msg t = Lwt.catch t (fun e -> Lwt_log.error (msg ^ ": " ^ (Printexc.to_string e)))
 let ignore_exn_delayed t () = Lwt.catch t (fun _ -> Lwt.return_unit)
+let ignore_exn_log_error = Cleanup.ignore_exn_log_error
 
 module StringSet = Set.Make(String)
-let blocks_to_close = Hashtbl.create 1
-let blocks_to_close_mutex = Lwt_mutex.create ()
 let vbds_to_clean_up = ref StringSet.empty
 let vbds_to_clean_up_mutex = Lwt_mutex.create ()
-
-let cleanup_vbds signal =
-  let cleanup () =
-    Lwt_log.warning_f "Caught signal %d, cleaning up" signal >>= fun () ->
-    ignore_exn_log_error "Caught exception while closing open block devices" (fun () ->
-        let cleanup b = ignore_exn_log_error "Caught exception while closing open block device" (fun () ->
-            Lwt_log.warning_f "Disconnecting from block device" >>= fun () ->
-            Block.disconnect b)
-        in
-        let blocks_to_close = Hashtbl.fold (fun _ b l -> b::l) blocks_to_close [] in
-        Lwt_list.iter_s cleanup blocks_to_close
-      ) >>= fun () ->
-    ignore_exn_log_error "Caught exception while cleaning up VBDs" (fun () ->
-        let rpc = Xen_api.make Consts.xapi_unix_domain_socket_uri in
-        Xen_api.Session.login_with_password ~rpc ~uname:"" ~pwd:"" ~version:"1.0" ~originator:"xapi-nbd" >>= fun session_id ->
-        let cleanup vbd = ignore_exn_log_error (Printf.sprintf "Caught exception while cleaning up VBD %s" vbd) (fun () ->
-            Lwt_log.warning_f "Cleaning up VBD %s" vbd >>= fun () ->
-            Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd >>= fun () ->
-            Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd)
-        in
-        StringSet.elements !vbds_to_clean_up
-        |> Lwt_list.iter_s cleanup
-      )
-  in
-  Lwt_main.run (cleanup ());
-  failwith (Printf.sprintf "Caught signal %d" signal)
-
-let register_signal_handler () =
-  let signals = [ Sys.sigint; Sys.sigterm ] in
-  List.iter
-    (fun s -> Lwt_unix.on_signal s cleanup_vbds |> ignore)
-    signals
 
 (* TODO share these "require" functions with the nbd package. *)
 let require name arg = match arg with
@@ -65,46 +31,6 @@ let require name arg = match arg with
 let require_str name arg =
   require name (if arg = "" then None else Some arg)
 
-let with_block filename f =
-  Block.connect filename
-  >>= function
-  | `Error e -> Lwt.fail_with (Printf.sprintf "Unable to read %s: %s" filename (Nbd.Block_error_printer.to_string e))
-  | `Ok b ->
-    let block_uuid = Uuidm.v `V4 |> Uuidm.to_string in
-    Lwt_mutex.with_lock blocks_to_close_mutex (fun () -> Lwt.wrap (fun () ->
-        Hashtbl.add blocks_to_close block_uuid b))
-    >>= fun () ->
-    Lwt.finalize
-      (fun () -> f b)
-      (fun () ->
-         Block.disconnect b >>= fun () ->
-         Lwt_mutex.with_lock blocks_to_close_mutex (fun () -> Lwt.wrap (fun () ->
-             Hashtbl.remove blocks_to_close block_uuid))
-      )
-
-let with_vbd ~vDI ~vM ~mode ~rpc ~session_id f =
-  Xen_api.VBD.create ~rpc ~session_id ~vM ~vDI ~userdevice:"autodetect" ~bootable:false ~mode ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]
-  >>= fun vbd ->
-  Lwt_mutex.with_lock vbds_to_clean_up_mutex (fun () -> Lwt.wrap (fun () ->
-      vbds_to_clean_up := StringSet.add vbd !vbds_to_clean_up))
-  >>= fun () ->
-  Lwt.finalize
-    (fun () ->
-       Lwt_log.notice_f "Plugging VBD %s" vbd >>= fun () ->
-       Xen_api.VBD.plug ~rpc ~session_id ~self:vbd >>= fun () ->
-       Lwt.finalize
-         (fun () -> f vbd)
-         (fun () ->
-            Lwt_log.notice_f "Unplugging VBD %s" vbd >>= fun () ->
-            Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd)
-    )
-    (fun () ->
-       Lwt_log.notice_f "Destroying VBD %s" vbd >>= fun () ->
-       Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd >>= fun () ->
-       Lwt_mutex.with_lock vbds_to_clean_up_mutex (fun () ->
-           vbds_to_clean_up := StringSet.remove vbd !vbds_to_clean_up; Lwt.return_unit)
-    )
-
 let with_attached_vdi vDI read_write rpc session_id f =
   Lwt_log.notice "Looking up control domain UUID in xensource inventory" >>= fun () ->
   Inventory.inventory_filename := Consts.xensource_inventory_filename;
@@ -112,7 +38,7 @@ let with_attached_vdi vDI read_write rpc session_id f =
   Lwt_log.notice "Found control domain UUID" >>= fun () ->
   Xen_api.VM.get_by_uuid ~rpc ~session_id ~uuid:control_domain_uuid
   >>= fun control_domain ->
-  with_vbd ~vDI ~vM:control_domain ~mode:(if read_write then `RW else `RO) ~rpc ~session_id (fun vbd ->
+  Cleanup.VBD.with_vbd ~vDI ~vM:control_domain ~mode:(if read_write then `RW else `RO) ~rpc ~session_id (fun vbd ->
       Xen_api.VBD.get_device ~rpc ~session_id ~self:vbd
       >>= fun device ->
       f ("/dev/" ^ device))
@@ -142,7 +68,7 @@ let handle_connection fd tls_role =
     >>= fun vdi_rec ->
     with_attached_vdi vdi_ref (not vdi_rec.API.vDI_read_only) rpc session_id
       (fun filename ->
-         with_block filename (Nbd_lwt_unix.Server.serve t (module Block))
+         Cleanup.Block.with_block filename (Nbd_lwt_unix.Server.serve t (module Block))
       )
   in
 
@@ -170,6 +96,7 @@ let init_tls_get_server_ctx ~certfile ~ciphersuites no_tls =
 let main port certfile ciphersuites no_tls =
   let t () =
     Lwt_log.notice_f "Starting xapi-nbd: port = '%d'; certfile = '%s'; ciphersuites = '%s' no_tls = '%b'" port certfile ciphersuites no_tls >>= fun () ->
+    Cleanup.Persistent.cleanup () >>= fun () ->
     Lwt_log.notice "Initialising TLS" >>= fun () ->
     let tls_role = init_tls_get_server_ctx ~certfile ~ciphersuites no_tls in
     let sock = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
@@ -255,7 +182,7 @@ let setup_logging () =
   Lwt_log.add_rule "*" Lwt_log.Notice
 
 let () =
-  register_signal_handler ();
+  Cleanup.Runtime.register_signal_handler ();
   setup_logging ();
   match Term.eval cmd with
   | `Error _ -> exit 1

--- a/src/main.ml
+++ b/src/main.ml
@@ -16,6 +16,34 @@ open Lwt.Infix
 (* Xapi external interfaces: *)
 module Xen_api = Xen_api_lwt_unix
 
+let ignore_exn t = Lwt.catch t (fun _ -> Lwt.return_unit)
+let ignore_exn_delayed t () = Lwt.catch t (fun _ -> Lwt.return_unit)
+
+module StringSet = Set.Make(String)
+let vbds_to_clean_up = ref StringSet.empty
+
+let cleanup_vbds signal =
+  let cleanup () =
+    Lwt_log.warning_f "Caught signal %d, cleaning up" signal >>= fun () ->
+    let rpc = Xen_api.make Consts.xapi_unix_domain_socket_uri in
+    Xen_api.Session.login_with_password ~rpc ~uname:"" ~pwd:"" ~version:"1.0" ~originator:"xapi-nbd" >>= fun session_id ->
+    let cleanup vbd = ignore_exn (fun () ->
+        Lwt_log.warning_f "Cleaning up VBD %s" vbd >>= fun () ->
+        Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd >>= fun () ->
+        Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd)
+    in
+    StringSet.elements !vbds_to_clean_up
+    |> Lwt_list.iter_s cleanup
+  in
+  Lwt_main.run (cleanup ());
+  failwith (Printf.sprintf "Caught signal %d" signal)
+
+let register_signal_handler () =
+  let signals = [ Sys.sigint; Sys.sigterm ] in
+  List.iter
+    (fun s -> Lwt_unix.on_signal s cleanup_vbds |> ignore)
+    signals
+
 (* TODO share these "require" functions with the nbd package. *)
 let require name arg = match arg with
   | None -> failwith (Printf.sprintf "Please supply a %s argument" name)
@@ -33,6 +61,25 @@ let with_block filename f =
       (fun () -> f x)
       (fun () -> Block.disconnect x)
 
+let with_vbd ~vDI ~vM ~mode ~rpc ~session_id f =
+  Xen_api.VBD.create ~rpc ~session_id ~vM ~vDI ~userdevice:"autodetect" ~bootable:false ~mode ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]
+  >>= fun vbd ->
+  vbds_to_clean_up := StringSet.add vbd !vbds_to_clean_up;
+  Lwt.finalize
+    (fun () ->
+       Lwt_log.notice_f "Plugging VBD %s" vbd >>= fun () ->
+       Xen_api.VBD.plug ~rpc ~session_id ~self:vbd >>= fun () ->
+       Lwt.finalize
+         (fun () -> f vbd)
+         (fun () ->
+            Lwt_log.notice_f "Unplugging VBD %s" vbd >>= fun () ->
+            Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd)
+    )
+    (fun () ->
+       Lwt_log.notice_f "Destroying VBD %s" vbd >>= fun () ->
+       Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd >|= fun () ->
+       vbds_to_clean_up := StringSet.remove vbd !vbds_to_clean_up)
+
 let with_attached_vdi vDI read_write rpc session_id f =
   Lwt_log.notice "Looking up control domain UUID in xensource inventory" >>= fun () ->
   Inventory.inventory_filename := Consts.xensource_inventory_filename;
@@ -40,27 +87,12 @@ let with_attached_vdi vDI read_write rpc session_id f =
   Lwt_log.notice "Found control domain UUID" >>= fun () ->
   Xen_api.VM.get_by_uuid ~rpc ~session_id ~uuid:control_domain_uuid
   >>= fun control_domain ->
-  Xen_api.VBD.create ~rpc ~session_id ~vM:control_domain ~vDI ~userdevice:"autodetect" ~bootable:false ~mode:(if read_write then `RW else `RO) ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]
-  >>= fun vbd ->
-  Lwt_log.notice_f "Created VBD %s" vbd >>= fun () ->
-  Lwt.finalize
-    (fun () ->
-      Lwt_log.notice_f "Plugging VBD %s" vbd >>= fun () ->
-      Xen_api.VBD.plug ~rpc ~session_id ~self:vbd
-      >>= fun () ->
-      Lwt.finalize
-      (fun () ->
-        Xen_api.VBD.get_device ~rpc ~session_id ~self:vbd
-        >>= fun device ->
-        f ("/dev/" ^ device))
-      (fun () -> Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd))
-    (fun () ->
-      Lwt_log.notice_f "Destroying VBD %s" vbd >>= fun () ->
-      Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd)
+  with_vbd ~vDI ~vM:control_domain ~mode:(if read_write then `RW else `RO) ~rpc ~session_id (fun vbd ->
+      Xen_api.VBD.get_device ~rpc ~session_id ~self:vbd
+      >>= fun device ->
+      f ("/dev/" ^ device))
 
-let ignore_exn t () = Lwt.catch t (fun _ -> Lwt.return_unit)
-
-let handle_connection xen_api_uri fd tls_role =
+let handle_connection fd tls_role =
 
   let with_session rpc uri f =
     ( match Uri.get_query_param uri "session_id" with
@@ -93,7 +125,7 @@ let handle_connection xen_api_uri fd tls_role =
     (fun channel ->
        Nbd_lwt_unix.Server.with_connection channel
          (fun export_name svr ->
-           let rpc = Xen_api.make xen_api_uri in
+           let rpc = Xen_api.make Consts.xapi_unix_domain_socket_uri in
            let uri = Uri.of_string export_name in
            with_session rpc uri (serve svr)
          )
@@ -110,9 +142,9 @@ let init_tls_get_server_ctx ~certfile ~ciphersuites no_tls =
     )
   )
 
-let main port xen_api_uri certfile ciphersuites no_tls =
+let main port certfile ciphersuites no_tls =
   let t () =
-    Lwt_log.notice_f "Starting xapi-nbd: port = '%d'; xen_api_uri = '%s'; certfile = '%s'; ciphersuites = '%s' no_tls = '%b'" port xen_api_uri certfile ciphersuites no_tls >>= fun () ->
+    Lwt_log.notice_f "Starting xapi-nbd: port = '%d'; certfile = '%s'; ciphersuites = '%s' no_tls = '%b'" port certfile ciphersuites no_tls >>= fun () ->
     Lwt_log.notice "Initialising TLS" >>= fun () ->
     let tls_role = init_tls_get_server_ctx ~certfile ~ciphersuites no_tls in
     let sock = Lwt_unix.socket Unix.PF_INET Unix.SOCK_STREAM 0 in
@@ -133,9 +165,9 @@ let main port xen_api_uri certfile ciphersuites no_tls =
              Lwt.catch
                (fun () ->
                   Lwt.finalize
-                    (fun () -> handle_connection xen_api_uri fd tls_role)
+                    (fun () -> handle_connection fd tls_role)
                     (* ignore the exception resulting from double-closing the socket *)
-                    (ignore_exn (fun () -> Lwt_unix.close fd))
+                    (ignore_exn_delayed (fun () -> Lwt_unix.close fd))
                )
                (fun e -> Lwt_log.error_f "Caught exception while handling client: %s" (Printexc.to_string e))
            in
@@ -143,7 +175,7 @@ let main port xen_api_uri certfile ciphersuites no_tls =
          in
          loop ()
       )
-      (ignore_exn (fun () -> Lwt_unix.close sock))
+      (ignore_exn_delayed (fun () -> Lwt_unix.close sock))
   in
   (* Log unexpected exceptions *)
   Lwt_main.run
@@ -190,10 +222,7 @@ let cmd =
   let port =
     let doc = "Local port to listen for connections on" in
     Arg.(value & opt int Consts.standard_nbd_port & info [ "port" ] ~doc) in
-  let xen_api_uri =
-    let doc = "The URI to use when making XenAPI calls. It must point to the pool master, or to xapi's local Unix domain socket, which is the default." in
-    Arg.(value & opt string Consts.xapi_unix_domain_socket_uri & info [ "xen-api-uri" ] ~doc) in
-  Term.(ret (pure main $ port $ xen_api_uri $ certfile $ ciphersuites $ no_tls)),
+  Term.(ret (pure main $ port $ certfile $ ciphersuites $ no_tls)),
   Term.info "xapi-nbd" ~version:"1.0.0" ~doc ~man ~sdocs:_common_options
 
 let setup_logging () =
@@ -202,6 +231,7 @@ let setup_logging () =
   Lwt_log.add_rule "*" Lwt_log.Notice
 
 let () =
+  register_signal_handler ();
   setup_logging ();
   match Term.eval cmd with
   | `Error _ -> exit 1

--- a/src/main.ml
+++ b/src/main.ml
@@ -16,33 +16,6 @@ open Lwt.Infix
 (* Xapi external interfaces: *)
 module Xen_api = Xen_api_lwt_unix
 
-(* Xapi internal interfaces: *)
-module SM = Storage_interface.ClientM(struct
-    type 'a t = 'a Lwt.t
-    let fail, return, bind = Lwt.(fail, return, bind)
-
-    let (>>*=) m f = m >>= function
-      | `Ok x -> f x
-      | `Error e ->
-        let b = Buffer.create 16 in
-        let fmt = Format.formatter_of_buffer b in
-        Protocol_lwt.Client.pp_error fmt e;
-        Format.pp_print_flush fmt ();
-        Lwt.fail_with (Buffer.contents b)
-
-    (* A global connection for the lifetime of this process *)
-    let switch =
-      Protocol_lwt.Client.connect ~switch:!Xcp_client.switch_path ()
-      >>*= fun switch ->
-      Lwt.return switch
-
-    let rpc call =
-      switch >>= fun switch ->
-      Protocol_lwt.Client.rpc ~t:switch ~queue:!Storage_interface.queue_name ~body:(Jsonrpc.string_of_call call) ()
-      >>*= fun result ->
-      Lwt.return (Jsonrpc.response_of_string result)
-  end)
-
 (* TODO share these "require" functions with the nbd package. *)
 let require name arg = match arg with
   | None -> failwith (Printf.sprintf "Please supply a %s argument" name)
@@ -71,23 +44,29 @@ let with_block filename f =
     >>= fun () ->
     release_exception r
 
-let with_attached_vdi sr vdi read_write f =
-  let pid = Unix.getpid () in
-  let connection_uuid = Uuidm.v `V4 |> Uuidm.to_string in
-  let datapath_id = Printf.sprintf "xapi-nbd/%s/%s/%d" vdi connection_uuid pid in
-  let dbg = Printf.sprintf "xapi-nbd:with_attached_vdi/%s" datapath_id in
-  SM.DP.create ~dbg ~id:datapath_id
-  >>= fun dp ->
-  SM.VDI.attach ~dbg ~dp ~sr ~vdi ~read_write
-  >>= fun attach_info ->
-  SM.VDI.activate ~dbg ~dp ~sr ~vdi
-  >>= fun () ->
-  capture_exception f attach_info.Storage_interface.params
-  >>= fun r ->
-  SM.DP.destroy ~dbg ~dp ~allow_leak:true
-  >>= fun () ->
-  release_exception r
-
+let with_attached_vdi vDI read_write rpc session_id f =
+  Lwt_log.notice "Looking up control domain UUID in xensource inventory" >>= fun () ->
+  Inventory.inventory_filename := Consts.xensource_inventory_filename;
+  let control_domain_uuid = Inventory.lookup Inventory._control_domain_uuid in
+  Lwt_log.notice "Found control domain UUID" >>= fun () ->
+  Xen_api.VM.get_by_uuid ~rpc ~session_id ~uuid:control_domain_uuid
+  >>= fun control_domain ->
+  Xen_api.VBD.create ~rpc ~session_id ~vM:control_domain ~vDI ~userdevice:"autodetect" ~bootable:false ~mode:(if read_write then `RW else `RO) ~_type:`Disk ~unpluggable:true ~empty:false ~other_config:[] ~qos_algorithm_type:"" ~qos_algorithm_params:[]
+  >>= fun vbd ->
+  Lwt.finalize
+    (fun () ->
+      Lwt_log.notice_f "Plugging VBD %s" vbd >>= fun () ->
+      Xen_api.VBD.plug ~rpc ~session_id ~self:vbd
+      >>= fun () ->
+      Lwt.finalize
+      (fun () ->
+        Xen_api.VBD.get_device ~rpc ~session_id ~self:vbd
+        >>= fun device ->
+        f ("/dev/" ^ device))
+      (fun () -> Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd))
+    (fun () ->
+      Lwt_log.notice_f "Destroying VBD %s" vbd >>= fun () ->
+      Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd)
 
 let ignore_exn t () = Lwt.catch t (fun _ -> Lwt.return_unit)
 
@@ -114,9 +93,7 @@ let handle_connection xen_api_uri fd tls_role =
     >>= fun vdi_ref ->
     Xen_api.VDI.get_record ~rpc ~session_id ~self:vdi_ref
     >>= fun vdi_rec ->
-    Xen_api.SR.get_uuid ~rpc ~session_id ~self:vdi_rec.API.vDI_SR
-    >>= fun sr_uuid ->
-    with_attached_vdi sr_uuid vdi_rec.API.vDI_location (not vdi_rec.API.vDI_read_only)
+    with_attached_vdi vdi_ref (not vdi_rec.API.vDI_read_only) rpc session_id
       (fun filename ->
          with_block filename (Nbd_lwt_unix.Server.serve t (module Block))
       )

--- a/src/vbd_store.ml
+++ b/src/vbd_store.ml
@@ -58,7 +58,8 @@ let get_all () =
   Lwt_unix.file_exists vbd_list_file >>= fun exists ->
   if exists then
     Lwt_mutex.with_lock m (fun () ->
-        Lwt.catch (fun () -> Lwt_io.lines_of_file vbd_list_file |> Lwt_stream.to_list)
+        Lwt.catch
+          (fun () -> Lwt_io.lines_of_file vbd_list_file |> Lwt_stream.to_list)
           (log_and_reraise_error ("Failed to read " ^ vbd_list_file))
       )
   else

--- a/src/vbd_store.ml
+++ b/src/vbd_store.ml
@@ -1,6 +1,14 @@
 open Lwt.Infix
 
+let section = Lwt_log.Section.make "Vbd_store"
+
+let vbd_list_file = Consts.(xapi_nbd_persistent_dir ^ "/" ^ vbd_list_file_name)
+
 let m = Lwt_mutex.create ()
+
+let log_and_reraise_error msg e =
+  Lwt_log.error_f ~section "%s: %s" msg (Printexc.to_string e) >>= fun () ->
+  Lwt.fail e
 
 let create_dir_if_doesnt_exist () =
   Lwt.catch
@@ -8,18 +16,31 @@ let create_dir_if_doesnt_exist () =
     (function
       | Unix.(Unix_error (EEXIST, "mkdir", dir)) when dir = Consts.xapi_nbd_persistent_dir -> Lwt.return_unit
       | e ->
-        Lwt_log.error_f "Failed to create directory: %s" (Printexc.to_string e)
+        (* In this we should let the client fail and the user/admin fix the permission/space/... issue that caused the failure *)
+        log_and_reraise_error "Failed to create directory" e
     )
 
 let transform_vbd_list f =
   Lwt_mutex.with_lock m (fun () ->
       create_dir_if_doesnt_exist () >>= fun () ->
-      (try
-         Lwt_io.lines_of_file Consts.vbd_list_file |> Lwt_stream.to_list
-       with _ -> Lwt.return [])
+      (* We cannot have one stream here piped through a chain of functions,
+         because the beginning of the stream (Lwt_io.lines_of_file) would read
+         what the end of the stream writes (Lwt_io.lines_to_file), and it would
+         overwrite the original file with duplicate entries. Instead, we read
+         the whole stream into a list here to ensure the file gets closed. *)
+      Lwt.catch
+        (fun () -> Lwt_io.lines_of_file vbd_list_file |> Lwt_stream.to_list)
+        (function
+          | Unix.(Unix_error (ENOENT, "open", file)) when file = vbd_list_file -> Lwt.return []
+          | e ->
+            (* In this we should let the client fail and the user/admin fix the permission/... issue that caused the failure *)
+            log_and_reraise_error ("Failed to read file " ^ vbd_list_file) e
+        )
       >>= fun l ->
       let l = f l in
-      Lwt_stream.of_list l |> Lwt_io.lines_to_file Consts.vbd_list_file
+      Lwt.catch
+        (fun () -> Lwt_stream.of_list l |> Lwt_io.lines_to_file vbd_list_file)
+        (log_and_reraise_error ("Failed to write to " ^ vbd_list_file))
     )
 
 let add vbd_uuid =
@@ -29,9 +50,16 @@ let remove vbd_uuid =
   transform_vbd_list (List.filter ((<>) vbd_uuid))
 
 let get_all () =
-  Lwt_unix.file_exists Consts.vbd_list_file >>= fun exists ->
+  (* Nothing should delete the vbd_list_file, so we do not have to use a
+     Lwt.catch block here to prevent races where the file gets deleted after we
+     check that it exists but before we use it. If it does get deleted, then it
+     is fine to fail here, because that was done by an external program and is
+     an error that the user/admin should fix. *)
+  Lwt_unix.file_exists vbd_list_file >>= fun exists ->
   if exists then
     Lwt_mutex.with_lock m (fun () ->
-        Lwt_io.lines_of_file Consts.vbd_list_file |> Lwt_stream.to_list)
+        Lwt.catch (fun () -> Lwt_io.lines_of_file vbd_list_file |> Lwt_stream.to_list)
+          (log_and_reraise_error ("Failed to read " ^ vbd_list_file))
+      )
   else
     Lwt.return []

--- a/src/vbd_store.ml
+++ b/src/vbd_store.ml
@@ -16,7 +16,7 @@ let create_dir_if_doesnt_exist () =
     (function
       | Unix.(Unix_error (EEXIST, "mkdir", dir)) when dir = Consts.xapi_nbd_persistent_dir -> Lwt.return_unit
       | e ->
-        (* In this we should let the client fail and the user/admin fix the permission/space/... issue that caused the failure *)
+        (* In any other case we let the client fail. In this case the user/admin should go and fix the root cause of the issue *)
         log_and_reraise_error "Failed to create directory" e
     )
 
@@ -33,7 +33,7 @@ let transform_vbd_list f =
         (function
           | Unix.(Unix_error (ENOENT, "open", file)) when file = vbd_list_file -> Lwt.return []
           | e ->
-            (* In this we should let the client fail and the user/admin fix the permission/... issue that caused the failure *)
+            (* In any other case we let the client fail. In this case the user/admin should go and fix the root cause of the issue *)
             log_and_reraise_error ("Failed to read file " ^ vbd_list_file) e
         )
       >>= fun l ->

--- a/src/vbd_store.ml
+++ b/src/vbd_store.ml
@@ -17,7 +17,7 @@ let create_dir_if_doesnt_exist () =
       | Unix.(Unix_error (EEXIST, "mkdir", dir)) when dir = Consts.xapi_nbd_persistent_dir -> Lwt.return_unit
       | e ->
         (* In any other case we let the client fail. In this case the user/admin should go and fix the root cause of the issue *)
-        log_and_reraise_error "Failed to create directory" e
+        log_and_reraise_error ("Failed to create directory " ^ Consts.xapi_nbd_persistent_dir) e
     )
 
 let transform_vbd_list f =

--- a/src/vbd_store.ml
+++ b/src/vbd_store.ml
@@ -1,0 +1,37 @@
+open Lwt.Infix
+
+let m = Lwt_mutex.create ()
+
+let create_dir_if_doesnt_exist () =
+  Lwt.catch
+    (fun () -> Lwt_unix.mkdir Consts.xapi_nbd_persistent_dir 0o755)
+    (function
+      | Unix.(Unix_error (EEXIST, "mkdir", dir)) when dir = Consts.xapi_nbd_persistent_dir -> Lwt.return_unit
+      | e ->
+        Lwt_log.error_f "Failed to create directory: %s" (Printexc.to_string e)
+    )
+
+let transform_vbd_list f =
+  Lwt_mutex.with_lock m (fun () ->
+      create_dir_if_doesnt_exist () >>= fun () ->
+      (try
+         Lwt_io.lines_of_file Consts.vbd_list_file |> Lwt_stream.to_list
+       with _ -> Lwt.return [])
+      >>= fun l ->
+      let l = f l in
+      Lwt_stream.of_list l |> Lwt_io.lines_to_file Consts.vbd_list_file
+    )
+
+let add vbd_uuid =
+  transform_vbd_list (List.append [vbd_uuid])
+
+let remove vbd_uuid =
+  transform_vbd_list (List.filter ((<>) vbd_uuid))
+
+let get_all () =
+  Lwt_unix.file_exists Consts.vbd_list_file >>= fun exists ->
+  if exists then
+    Lwt_mutex.with_lock m (fun () ->
+        Lwt_io.lines_of_file Consts.vbd_list_file |> Lwt_stream.to_list)
+  else
+    Lwt.return []

--- a/src/vbd_store.mli
+++ b/src/vbd_store.mli
@@ -6,7 +6,11 @@
 
     The {!add} and {!remove} functions, which modify this persistent list,
     first check if the {!Consts.xapi_nbd_persistent_dir} directory exists,
-    and create it if it doesn't.
+    and create it if it doesn't. If the {!Consts.vbd_list_file_name}
+    file does not exist, they assume that the leaked VBD UUID list is
+    empty, and create the file. If any unexpected I/O errors occur, other
+    than the above file and directory not existing, the exception will be
+    propagated to the caller.
 *)
 
 (** [add vbd_uuid] adds [vbd_uuid] to the persistent list of VBD UUIDs, and

--- a/src/vbd_store.mli
+++ b/src/vbd_store.mli
@@ -1,0 +1,8 @@
+(** Read and write a persistent list of VBD UUIDs.
+    These functions are thread-safe. *)
+
+val add: string -> unit Lwt.t
+
+val remove: string -> unit Lwt.t
+
+val get_all: unit -> (string list) Lwt.t

--- a/src/vbd_store.mli
+++ b/src/vbd_store.mli
@@ -1,8 +1,25 @@
 (** Read and write a persistent list of VBD UUIDs.
-    These functions are thread-safe. *)
+    These functions are thread-safe.
 
+    The list is saved into a file with name {!Consts.vbd_list_file_name}
+    in the directory specified by {!Consts.xapi_nbd_persistent_dir}.
+
+    The {!add} and {!remove} functions, which modify this persistent list,
+    first check if the {!Consts.xapi_nbd_persistent_dir} directory exists,
+    and create it if it doesn't.
+*)
+
+(** [add vbd_uuid] adds [vbd_uuid] to the persistent list of VBD UUIDs, and
+    writes back the changes to disk. It does not check for duplicated VBD
+    UUIDs: if this UUID is already in the list, it will be added again. *)
 val add: string -> unit Lwt.t
 
+(** [remove vbd_uuid] removes [vbd_uuid] from the persistent list of VBD UUIDs,
+    and writes back the changes to disk. If this [vbd_uuid] occurs in the list
+    multiple times, all occurrences will be removed. *)
 val remove: string -> unit Lwt.t
 
+(** Returns all of the VBD UUIDs stored on disk. The UUIDs are not
+    deduplicated, if the same UUID is added multiple times using {!add}, then it
+    will be repeated here too. *)
 val get_all: unit -> (string list) Lwt.t

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -12,8 +12,7 @@ depends: [
   "mirage-block-unix"
   "nbd" {>= "2.0.1"}
   "uri"
-  "uuidm"
-  "xapi-idl"
+  "xapi-inventory"
   "xen-api-client"
 ]
 tags: [ "org:mirage" "org:xapi-project" ]

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -12,6 +12,7 @@ depends: [
   "mirage-block-unix"
   "nbd" {>= "2.0.1"}
   "uri"
+  "uuidm"
   "xapi-inventory"
   "xen-api-client"
 ]


### PR DESCRIPTION
Not it works in case of service stop, restart, and machine reboot. The only issue is that the client hangs after reboot.