### PR TITLE
Wait for xapi to be up before making XenAPI calls

### DIFF
--- a/src/cleanup.ml
+++ b/src/cleanup.ml
@@ -2,17 +2,50 @@ open Lwt.Infix
 
 module Xen_api = Xen_api_lwt_unix
 
-module StringSet = Set.Make(String)
+module Local_xapi_session = struct
+  let wait_for_xapi_and_login () =
+    let rpc = Xen_api.make Consts.xapi_unix_domain_socket_uri in
+    let rec loop () =
+      Lwt.catch
+        (fun () -> Xen_api.Session.login_with_password ~rpc ~uname:"" ~pwd:"" ~version:"1.0" ~originator:"xapi-nbd")
+        (fun e ->
+           Lwt_log.warning_f "Failed to log in via xapi's Unix domain socket: %s; retrying in %f seconds" (Printexc.to_string e) Consts.wait_for_xapi_retry_delay_seconds >>= fun () ->
+           Lwt_unix.sleep Consts.wait_for_xapi_retry_delay_seconds >>= fun () ->
+           loop ()
+        )
+    in
+
+    let timeout () =
+      let timeout_s = Consts.wait_for_xapi_timeout_seconds in
+      Lwt_unix.sleep timeout_s >>= fun () ->
+      let msg = Printf.sprintf "Failed to log in via xapi's Unix domain socket in %f seconds" timeout_s in
+      Lwt_log.fatal msg >>= fun () ->
+      Lwt.fail_with msg
+    in
+
+    Lwt_log.notice_f "Trying to log in via xapi's Unix domain socket for %f seconds" Consts.wait_for_xapi_timeout_seconds >>= fun () ->
+    Lwt.pick [loop (); timeout ()] >|= fun session_id ->
+    (rpc, session_id)
+
+  (** [with_session f] logs in as the local superuser via xapi's local Unix
+      domain socket, and takes care to close the session when [f] finishes. It
+      keeps retrying the login requests up to
+      {!Consts.wait_for_xapi_timeout_seconds} seconds. If it does not manage to
+      log in before this timeout, it fails with an exception. It waits for
+      {!Consts.wait_for_xapi_retry_delay_seconds} seconds between subsequent
+      login attempts. *)
+  let with_session f =
+    wait_for_xapi_and_login () >>= fun (rpc, session_id) ->
+    Lwt.finalize
+      (fun () -> f rpc session_id)
+      (fun () -> Xen_api.Session.logout ~rpc ~session_id)
+end
 
 let ignore_exn_log_error msg t = Lwt.catch t (fun e -> Lwt_log.error (msg ^ ": " ^ (Printexc.to_string e)))
 
-let local_login () =
-  let rpc = Xen_api.make Consts.xapi_unix_domain_socket_uri in
-  Xen_api.Session.login_with_password ~rpc ~uname:"" ~pwd:"" ~version:"1.0" ~originator:"xapi-nbd" >|= fun session_id ->
-  (rpc, session_id)
-
-
 module VBD = struct
+  module StringSet = Set.Make(String)
+
   let cleanup_vbd rpc session_id vbd =
     Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd >>= fun () ->
     Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd
@@ -158,8 +191,7 @@ module Runtime = struct
           Block.Runtime.cleanup ())
       >>= fun () ->
       ignore_exn_log_error "Caught exception while cleaning up VBDs" (fun () ->
-          local_login () >>= fun (rpc, session_id) ->
-          VBD.Runtime.cleanup rpc session_id
+          Local_xapi_session.with_session VBD.Runtime.cleanup
         )
     in
 
@@ -175,6 +207,5 @@ end
 
 module Persistent = struct
   let cleanup () =
-    local_login () >>= fun (rpc, session_id) ->
-    VBD.Persistent.cleanup rpc session_id
+    Local_xapi_session.with_session VBD.Persistent.cleanup
 end

--- a/src/cleanup.ml
+++ b/src/cleanup.ml
@@ -23,7 +23,7 @@ module Local_xapi_session = struct
       Lwt.fail_with msg
     in
 
-    Lwt_log.notice_f "Trying to log in via xapi's Unix domain socket for %f seconds" Consts.wait_for_xapi_timeout_seconds >>= fun () ->
+    Lwt_log.notice_f "Will try to log in via xapi's Unix domain socket for %f seconds" Consts.wait_for_xapi_timeout_seconds >>= fun () ->
     Lwt.pick [loop (); timeout ()] >|= fun session_id ->
     (rpc, session_id)
 

--- a/src/consts.ml
+++ b/src/consts.ml
@@ -17,7 +17,7 @@ let vbd_list_file_name = "VBDs_to_clean_up"
 (** When logging in via xapi's Unix domain socket to perform some cleanups, we
     keep trying to log in up to this many seconds, because xapi may not be
     ready when xapi-nbd starts up. *)
-let wait_for_xapi_timeout_seconds = 120.0
+let wait_for_xapi_timeout_seconds = 300.0
 
 (** We sleep for this many seconds before the next login attempt. *)
 let wait_for_xapi_retry_delay_seconds = 4.0

--- a/src/consts.ml
+++ b/src/consts.ml
@@ -13,3 +13,11 @@ let project_url = "http://github.com/xapi-project/xapi-nbd"
 let xapi_nbd_persistent_dir = "/var/lib/xapi-nbd"
 
 let vbd_list_file_name = "VBDs_to_clean_up"
+
+(** When logging in via xapi's Unix domain socket to perform some cleanups, we
+    keep trying to log in up to this many seconds, because xapi may not be
+    ready when xapi-nbd starts up. *)
+let wait_for_xapi_timeout_seconds = 120.0
+
+(** We sleep for this many seconds before the next login attempt. *)
+let wait_for_xapi_retry_delay_seconds = 4.0

--- a/src/main.ml
+++ b/src/main.ml
@@ -19,10 +19,6 @@ module Xen_api = Xen_api_lwt_unix
 let ignore_exn_delayed t () = Lwt.catch t (fun _ -> Lwt.return_unit)
 let ignore_exn_log_error = Cleanup.ignore_exn_log_error
 
-module StringSet = Set.Make(String)
-let vbds_to_clean_up = ref StringSet.empty
-let vbds_to_clean_up_mutex = Lwt_mutex.create ()
-
 (* TODO share these "require" functions with the nbd package. *)
 let require name arg = match arg with
   | None -> failwith (Printf.sprintf "Please supply a %s argument" name)


### PR DESCRIPTION
Previously when the server tried to login at startup, it failed
immediately because xapi wasn't ready yet, even though systemd starts
xapi-nbd after xapi. The proper long term fix will be for xapi to notify
systemd when its startup sequence has completed, and when that is done,
this temporary fix can be removed.

Waiting for xapi's Unix domain socket to be up does not work, there
would still be transient failures because apparently xapi is not
completely ready when the Unix domain socket is created.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>

Fixes #19 