### PR TITLE
Update dependencies to work with xen-api-client 0.11.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ env:
     - OCAML_VERSION=4.04.2
     - DISTRO=debian-stable
     - PACKAGE=xapi-nbd
-    - PINS="nbd:git://github.com/xapi-project/nbd.git#bugfix-v2.x"
+    - PINS="nbd:git://github.com/xapi-project/nbd.git#bugfix-v2.x xen-api-client:git://github.com/xapi-project/xen-api-client#feature/CBT xen-api-client-lwt:git://github.com/xapi-project/xen-api-client#feature/CBT xen-api-client-async:git://github.com/xapi-project/xen-api-client#feature/CBT"
   matrix:
     - BASE_REMOTE=git://github.com/xapi-project/xs-opam
     - EXTRA_REMOTES=git://github.com/xapi-project/xs-opam

--- a/lib/jbuild
+++ b/lib/jbuild
@@ -11,7 +11,7 @@
    (consts
     lwt
     lwt.unix
-    xen-api-client.lwt
+    xen-api-client-lwt
    )
   )
  )

--- a/src/jbuild
+++ b/src/jbuild
@@ -15,6 +15,6 @@
     uuidm
     vbd_store
     xcp-inventory
-    xen-api-client.lwt))
+    xen-api-client-lwt))
  )
 )

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -16,6 +16,6 @@ depends: [
   "uri"
   "uuidm"
   "xapi-inventory"
-  "xen-api-client"
+  "xen-api-client-lwt"
 ]
 tags: [ "org:mirage" "org:xapi-project" ]


### PR DESCRIPTION
This version is built with jbuilder and has been split into multiple
packages.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>