### PR TITLE
CP-24919: Specify a timeout for IO with client.

### DIFF
--- a/lib/consts.ml
+++ b/lib/consts.ml
@@ -24,3 +24,7 @@ let wait_for_xapi_retry_delay_seconds = 4.0
 
 (** Allow no more than this many client connections. *)
 let connection_limit = 16
+
+(** Disconnect any client connection that keeps us waiting this long
+    for a read or write. *)
+let socket_timeout_seconds = 17.0

--- a/src/main.ml
+++ b/src/main.ml
@@ -69,7 +69,7 @@ let handle_connection fd tls_role =
       )
   in
 
-  Nbd_lwt_unix.with_channel fd tls_role
+  Nbd_lwt_unix.with_channel ~timeout_seconds:Consts.socket_timeout_seconds fd tls_role
     (fun channel ->
        Nbd_lwt_unix.Server.with_connection channel
          (fun export_name svr ->
@@ -146,8 +146,9 @@ let main port certfile ciphersuites =
                (fun () ->
                   Lwt.finalize
                     (fun () -> (
-                      inc_conn () >>=
-                      xapi_says_use_tls >>=
+                      inc_conn () >>= fun () ->
+                      Lwt_unix.setsockopt fd Lwt_unix.SO_KEEPALIVE true;
+                      xapi_says_use_tls () >>=
                       fun tls -> (
                         let tls_role = if tls then tls_server_role else None in
                         handle_connection fd tls_role)

--- a/src/main.ml
+++ b/src/main.ml
@@ -145,14 +145,12 @@ let main port certfile ciphersuites =
              ignore_exn_log_error "Caught exception while handling client"
                (fun () ->
                   Lwt.finalize
-                    (fun () -> (
+                    (fun () ->
                       inc_conn () >>= fun () ->
                       Lwt_unix.setsockopt fd Lwt_unix.SO_KEEPALIVE true;
-                      xapi_says_use_tls () >>=
-                      fun tls -> (
-                        let tls_role = if tls then tls_server_role else None in
-                        handle_connection fd tls_role)
-                      )
+                      xapi_says_use_tls () >>= fun tls ->
+                      let tls_role = if tls then tls_server_role else None in
+                      handle_connection fd tls_role
                     )
                     (* ignore the exception resulting from double-closing the socket *)
                     (fun () ->


### PR DESCRIPTION
This will get rid of idle clients.