### PR TITLE
CA-298461 use local session for cleanups

### DIFF
--- a/src/cleanup.ml
+++ b/src/cleanup.ml
@@ -81,7 +81,7 @@ module VBD = struct
         (fun () -> Vbd_store.remove vbd_uuid)
 
     let cleanup () =
-    Local_xapi_session.with_session @@ fun rpc session_id ->
+      Local_xapi_session.with_session @@ fun rpc session_id ->
       Lwt_log.notice_f "Checking if there are any VBDs to clean up that leaked during the previous run" >>= fun () ->
       Vbd_store.get_all () >>= fun vbd_uuids ->
       Lwt_list.iter_s

--- a/src/cleanup.ml
+++ b/src/cleanup.ml
@@ -70,6 +70,7 @@ module VBD = struct
           (fun () -> a)
           b
           (fun e ->
+             Local_xapi_session.with_session @@ fun rpc session_id ->
              Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd >>= fun () ->
              Lwt.fail e)
       in
@@ -116,10 +117,12 @@ module VBD = struct
                    (fun () -> f vbd)
                    (fun () ->
                       Lwt_log.notice_f "Unplugging VBD %s" (API.Ref.string_of vbd) >>= fun () ->
+                      Local_xapi_session.with_session @@ fun rpc session_id ->
                       Xen_api.VBD.unplug ~rpc ~session_id ~self:vbd)
               )
               (fun () ->
                  Lwt_log.notice_f "Destroying VBD %s" (API.Ref.string_of vbd) >>= fun () ->
+                 Local_xapi_session.with_session @@ fun rpc session_id ->
                  Xen_api.VBD.destroy ~rpc ~session_id ~self:vbd
               )
           )


### PR DESCRIPTION
To avoid races during shutdown, cleanup operations should use local
sessions rather than the client session.

Signed-off-by: Christian Lindig <christian.lindig@citrix.com>