### PR TITLE
Reference xapi-inventory as xcp-invenotry is being deprecated.

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -12,6 +12,6 @@
   uri
   uuidm
   vbd_store
-  xcp-inventory
+  xapi-inventory
   xen-api-client-lwt)
 )

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -1,11 +1,13 @@
-opam-version: "1.2"
+opam-version: "2.0"
 maintainer: "xen-api@lists.xen.org"
 authors: ["dave.scott@citrix.com"]
 homepage: "https://github.com/xapi-project/xapi-nbd"
 bug-reports: "https://github.com/xapi-project/xapi-nbd/issues"
-dev-repo: "https://github.com/xapi-project/xapi-nbd.git"
-build: [[ make "release" ]]
-build-test: [[ "dune" "runtest" ]]
+dev-repo: "git+https://github.com/xapi-project/xapi-nbd.git"
+build: [
+  [ make "release" ]
+]
+run-test: [[ "dune" "runtest" "-p" name "-j" jobs ]]
 depends: [
   "dune" {build}
   "alcotest" {test}


### PR DESCRIPTION
Signed-off-by: Konstantina Chremmou <konstantina.chremmou@citrix.com>