### PR TITLE
Make it compatible with Lwt 4

### DIFF
--- a/lib/dune
+++ b/lib/dune
@@ -10,6 +10,7 @@
   consts
   lwt
   lwt.unix
+  lwt_log
   xen-api-client-lwt
  )
 )
@@ -19,6 +20,7 @@
  (libraries
   lwt
   lwt.unix
+  lwt_log
  )
  (modules vbd_store)
 )

--- a/src/dune
+++ b/src/dune
@@ -7,6 +7,7 @@
   local_xapi_session
   lwt
   lwt.unix
+  lwt_log
   mirage-block-unix
   nbd-lwt-unix
   uri

--- a/xapi-nbd.opam
+++ b/xapi-nbd.opam
@@ -14,6 +14,7 @@ depends: [
   "alcotest-lwt" {test}
   "cmdliner"
   "lwt" {>= "3.0.0"}
+  "lwt_log"
   "mirage-block-unix"
   "nbd-lwt-unix"
   "uri"


### PR DESCRIPTION
Lwt_log has been moved into a different opam package & ocamlfind
library. These changes are compatible with the old Lwt too.

Signed-off-by: Gabor Igloi <gabor.igloi@citrix.com>