### PR TITLE
CA-307773: initialize EC curve to the one XAPI would use

### DIFF
--- a/src/main.ml
+++ b/src/main.ml
@@ -82,7 +82,7 @@ let init_tls_get_server_ctx ~certfile ~ciphersuites =
   let certfile = require_str "certfile" certfile in
   let ciphersuites = require_str "ciphersuites" ciphersuites in
   Some (Nbd_lwt_unix.TlsServer
-    (Nbd_lwt_unix.init_tls_get_ctx ~certfile ~ciphersuites)
+    (Nbd_lwt_unix.init_tls_get_ctx ~curve:"secp384r1" ~certfile ~ciphersuites)
   )
 
 let xapi_says_use_tls () =


### PR DESCRIPTION
See https://github.com/xapi-project/nbd/pull/147 I think this will need a new xs-opam release.