### PR TITLE
CP-33058 centralize cipherstrings

### DIFF
--- a/src/dune
+++ b/src/dune
@@ -13,5 +13,6 @@
   uuidm
   vbd_store
   xapi-inventory
-  xen-api-client-lwt)
+  xen-api-client-lwt
+  xapi-idl)
 )


### PR DESCRIPTION
Ignore cipherstring passed via the command line, deferring to the
centralized cipherstring instead

Signed-off-by: lippirk <ben.anson@citrix.com>